### PR TITLE
Bind the config instance to the ioc

### DIFF
--- a/src/StripeServiceProvider.php
+++ b/src/StripeServiceProvider.php
@@ -31,6 +31,7 @@ class StripeServiceProvider extends ServiceProvider
     public function register()
     {
         $this->registerStripe();
+        $this->registerConfig();
     }
 
     /**
@@ -61,5 +62,22 @@ class StripeServiceProvider extends ServiceProvider
         });
 
         $this->app->alias('stripe', 'Cartalyst\Stripe\Stripe');
+    }
+
+    /**
+     * Register the config class.
+     *
+     * @return void
+     */
+    protected function registerConfig()
+    {
+        $this->app->bindShared('stripe.config', function ($app) {
+            $stripe = $app['stripe'];
+
+            return $stripe->getConfig();
+        });
+
+        $this->app->alias('stripe.config', 'Cartalyst\Stripe\Config');
+        $this->app->alias('stripe.config', 'Cartalyst\Stripe\ConfigInterface');
     }
 }


### PR DESCRIPTION
This means all the "API" classes should be resolvable from the ioc container now.

---

Closes https://github.com/cartalyst/stripe/issues/34.
