### PR TITLE
allow laravel 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "illuminate/support": "5.5.*",
+        "illuminate/support": "~5.5",
         "cartalyst/stripe": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This PR slightly adapts the `composer.json` file in order to support the newly released Laravel 5.6 version